### PR TITLE
handle relative redirects

### DIFF
--- a/install_pack.js
+++ b/install_pack.js
@@ -114,7 +114,7 @@ function hitFile (link, target, fname, cb) {
     let len = res.headers['content-length']
 
     if (res.headers.location) {
-      hitFile(res.headers.location, target, originalFname, cb)
+      hitFile(url.resolve(link, res.headers.location), target, originalFname, cb)
       return
     }
 


### PR DESCRIPTION
When executing the script I stumbled upon the message:
```
Hitting https://minecraft.curseforge.com/projects/226447/files/2477566/download
Hitting /projects/resource-loader/files/2477566/download
```
this was caused by a relative redirect at which the script lost all informations about the server, protocoll and port.

This fix lets "url.resolve" handle the resolvation of needed url-informations (such as relative redirects) and does not destroy absolute redirects (like 'Location: http://google.com/test').
  