### PR TITLE
Add error message if modpack is already downloaded

### DIFF
--- a/install_pack.py
+++ b/install_pack.py
@@ -84,6 +84,7 @@ def hit_file(url, target, file_name):
     write_to = os.path.join(target, file_name)
 
     if os.path.exists(write_to):
+        print('❌ Target "%s" already exists!' % (write_to))
         return None
 
     print('=> Hitting file at %s' % (url))


### PR DESCRIPTION
If you have already downloaded the modpack file (manually) the program will exit with:
```
Traceback (most recent call last):
  File "./install_pack.py", line 398, in <module>
    download_modpack(mppath)
  File "./install_pack.py", line 339, in download_modpack
    raise ValueError('Failed to download modpack!')
```

this pull request adds a human readable message if the file already exists.
It does however **not** handle/integrate/check-sum existing files.